### PR TITLE
Initial rendering optimisation

### DIFF
--- a/js/jquery.amsifyselect.js
+++ b/js/jquery.amsifyselect.js
@@ -127,21 +127,24 @@
 
           	if(this.isOptGroup) {
             	$firstItem = $(this.selector).find('option:first');
+
             	if($firstItem.length) {
 	              	_self.options.push({
 	                                    type  : 'option',
 	                                    label : $firstItem.text(),
 	                                });
             	}
-	            $(this.selector).find('optgroup').each(function(index, optgroup){ // TODO: same as below - for let opt (no Jquery)
-	              	_self.options.push({
-	                                    type  : 'optgroup',
-	                                    label : $(optgroup).attr('label'),
-	                                });
-	              	$(optgroup).find('option').each(function(okey, option){
-	              		_self.addOption(option);
-	              	});
-	            });
+
+            	for (let optgroup of Array.from(this.selector.childNodes.values()).filter(e => e.tagName === 'OPTGROUP')) {
+					_self.options.push({
+										type  : 'optgroup',
+										label : $(optgroup).attr('label'),
+									});
+
+					for (let opt of optgroup.childNodes) {
+						_self.addOption(opt)
+					}
+				}
           	} else {
 				for (let opt of this.selector.childNodes) {
 					_self.addOption(opt);

--- a/js/jquery.amsifyselect.js
+++ b/js/jquery.amsifyselect.js
@@ -362,7 +362,6 @@
 		},
 
 		filterList : function(value) {
-        	console.log("BEF FILTER WITH VAL: " + value + " AT " + Date.now())
 			const _self = this;
 			var found = false;
 
@@ -396,7 +395,6 @@
 			if(!found) {
 				$(this.selectors.list).find(this.classes.noResult).show();
 			}
-			console.log("AFT FILTER WITH VAL: " + value + " AT " + Date.now())
 		},
 
         clearInputs : function() {

--- a/js/jquery.amsifyselect.js
+++ b/js/jquery.amsifyselect.js
@@ -120,19 +120,20 @@
 
         extractData : function() {
           	var _self = this;
+
           	this.isMultiple = !!$(this.selector).prop('multiple');
           	this.isOptGroup = !!$(this.selector).find('optgroup').length;
+			this.options = [];
 
           	if(this.isOptGroup) {
-            	$firstItem    = $(this.selector).find('option:first');
-            	_self.options = [];
+            	$firstItem = $(this.selector).find('option:first');
             	if($firstItem.length) {
 	              	_self.options.push({
 	                                    type  : 'option',
 	                                    label : $firstItem.text(),
 	                                });
             	}
-	            $(this.selector).find('optgroup').each(function(index, optgroup){
+	            $(this.selector).find('optgroup').each(function(index, optgroup){ // TODO: same as below - for let opt (no Jquery)
 	              	_self.options.push({
 	                                    type  : 'optgroup',
 	                                    label : $(optgroup).attr('label'),
@@ -142,41 +143,21 @@
 	              	});
 	            });
           	} else {
-            	$(this.selector).find('option').each(function(index, option){
-            		_self.addOption(option);
-              	});
+				for (let opt of this.selector.childNodes) {
+					_self.addOption(opt);
+				}
           	}
         },
 
-        isOptionExist : function(option) {
-        	var key = null;
-			if(this.options.length) {
-				$.each(this.options, function(i, e) {
-					if(typeof e === 'object') {
-						if(e.value === $(option).val()) {
-							present = true;
-							key = i;
-							return false;
-						}
-					}
-				});
-			}
-			return key;
-		},
-
 		addOption: function(option) {
-			var key = this.isOptionExist(option);
-			var data= {
+			const data = {
 						type      : 'option',
 						value     : $(option).val(),
 						label     : $(option).text(),
 						selected  : ($(option).attr('selected') !== undefined)? 1 : 0
-			          };
-      		if(key === null) {
-				this.options.push(data);
-			} else {
-				this.options[key] = data;
-			}
+			           };
+
+			this.options.push(data);
 		},
 
         createHTML : function() {

--- a/js/jquery.amsifyselect.js
+++ b/js/jquery.amsifyselect.js
@@ -344,7 +344,6 @@
 
 		filterList : function(value) {
 			const _self = this;
-			var found = false;
 
 			$(this.selectors.list).find(this.classes.noResult).hide();
 
@@ -358,22 +357,22 @@
 			lis.each(function(index, el){
 				if(el.innerText.toLowerCase().indexOf(value) !== -1) {
 					matchingLisIndices.push(index)
-					found = true;
 				}
 			});
 
 			lis.each(function(index, el){
-				if (matchingLisIndices.includes(index)) {
-					el.style.display = 'list-item'
-					if (_self.isOptGroup) {
-						$(el).prevAll(_self.classes.listGroup + ':first').show();
-					}
-				} else {
-					el.style.display = 'none'
-				}
+				el.style.display = 'none';
 			});
 
-			if(!found) {
+			for (let i of matchingLisIndices) {
+				const el = lis[i];
+				el.style.display = 'list-item';
+				if (_self.isOptGroup) {
+					$(el).prevAll(_self.classes.listGroup + ':first').show();
+				}
+			}
+
+			if(!matchingLisIndices.length) {
 				$(this.selectors.list).find(this.classes.noResult).show();
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amsifyselect",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "jquery": ">=3.4.0"
   },


### PR DESCRIPTION
Hi,

I've refactored the code even bit more to achieve better filtering (with large datasets) and initial rendering performance.

Here's the test results for the regular \<select> list filtering:
- Browser: Chrome 98.0.4758.102 on macOS Version 10.15.7
- Data: \<select> with the following values: 1 to 19998
  - Input (before refactoring MS - after refactoring MS):
    - 5: 228 - 75
    - 55: 63 - 49
    - 555 - 39 - 38
    - 5555 - 40 - 42
- Data: \<select> with the following \<option> values: 1 to 19998
  - Results:
    - Before refactoring average MS from 5 executions - 89303
    - After refactoring average MS from 5 executions - 65
- Data: \<select> with \<optgroup> initialisation with the following values (998 groups with 2 options (Math.random())
  - Results:
    - Before refactoring average MS from 5 executions - 22.8
    - After refactoring average MS from 5 executions - 14.2
